### PR TITLE
Add 3v3 support for Challenger Mode tournaments

### DIFF
--- a/packages/core/src/@types/types.ts
+++ b/packages/core/src/@types/types.ts
@@ -25,6 +25,7 @@ export type Entrant = {
 
   player1?: Player;
   player2?: Player;
+  player3?: Player;
 };
 
 export type PRInformation = {

--- a/packages/core/src/backends/cards/game.ts
+++ b/packages/core/src/backends/cards/game.ts
@@ -41,6 +41,7 @@ const emptyEntrant = (): Entrant => ({
   isLive: true,
   player1: emptyPlayer(),
   player2: emptyPlayer(),
+  player3: emptyPlayer(),
 });
 export const emptyPostGame = () => ({
   deaths: 0,
@@ -356,6 +357,8 @@ export class GameBackend extends Backend<State> {
           right.player1,
           left.player2,
           right.player2,
+          left.player3,
+          right.player3,
         ]
           .map(async (player, i) => {
             const pr = await this.pService.getPR(player?.id);
@@ -375,7 +378,11 @@ export class GameBackend extends Backend<State> {
           .concat(
             [left, right].map(async (entrant, i) => ({
               score: scores[i % 2],
-              name: [entrant.player1?.name, entrant.player2?.name]
+              name: [
+                entrant.player1?.name,
+                entrant.player2?.name,
+                entrant.player3?.name,
+              ]
                 .filter((a) => a)
                 .join("/"),
               country: "",
@@ -396,6 +403,9 @@ export class GameBackend extends Backend<State> {
 
         if (left.player2?.id || right.player2?.id) {
           live.push(left.player2, right.player2);
+        }
+        if (left.player3?.id || right.player3?.id) {
+          live.push(left.player3, right.player3);
         }
         await this.output.writeJSON(
           "live/game.json",

--- a/packages/core/src/backends/cards/players.ts
+++ b/packages/core/src/backends/cards/players.ts
@@ -66,11 +66,13 @@ export class PlayersBackend extends Backend<State> {
       isLive: true,
       player1: {},
       player2: {},
+      player3: {},
     },
     right: {
       isLive: true,
       player1: {},
       player2: {},
+      player3: {},
     },
     entrantSize: 1,
   };
@@ -98,16 +100,16 @@ export class PlayersBackend extends Backend<State> {
 
     this.on(() => {
       this.setState({
-        left: { isLive: true, player1: {}, player2: {} },
-        right: { isLive: true, player1: {}, player2: {} },
+        left: { isLive: true, player1: {}, player2: {}, player3: {} },
+        right: { isLive: true, player1: {}, player2: {}, player3: {} },
         entrantSize: this._tournament.state.sggTournament.entrantSize,
       });
     }, [this._tournament.state.sggTournament.eventId]);
 
     this.on(() => {
       this.setState({
-        left: { isLive: true, player1: {}, player2: {} },
-        right: { isLive: true, player1: {}, player2: {} },
+        left: { isLive: true, player1: {}, player2: {}, player3: {} },
+        right: { isLive: true, player1: {}, player2: {}, player3: {} },
         entrantSize: this._tournament.state.cmTournament.entrantSize,
       });
     }, [
@@ -124,7 +126,7 @@ export class PlayersBackend extends Backend<State> {
 
     if (!e.id) {
       return this.setState({
-        [side]: { isLive: true, player1: {}, player2: {} },
+        [side]: { isLive: true, player1: {}, player2: {}, player3: {} },
         [side + "Score"]: 0,
       });
     }
@@ -181,6 +183,8 @@ export class PlayersBackend extends Backend<State> {
           right.player1,
           left.player2,
           right.player2,
+          left.player3,
+          right.player3,
         ];
 
         const prs = await Promise.all(

--- a/packages/core/src/backends/cards/queue.ts
+++ b/packages/core/src/backends/cards/queue.ts
@@ -33,7 +33,9 @@ import {
 } from "../../@types/challengermode";
 
 const entrantName = (e: Entrant) =>
-  [e?.player1?.name, e?.player2?.name].filter((a) => a).join("/");
+  [e?.player1?.name, e?.player2?.name, e?.player3?.name]
+    .filter((a) => a)
+    .join("/");
 
 export type QueueSet = {
   id?: number | string;
@@ -447,6 +449,8 @@ export class QueueBackend extends Backend<State> {
                   qs.left?.player2?.id,
                   qs.right?.player1?.id,
                   qs.right?.player2?.id,
+                  qs.left?.player3?.id,
+                  qs.right?.player3?.id,
                 ].map((id) => this.pService.getPR(id))
               );
               return {
@@ -482,6 +486,20 @@ export class QueueBackend extends Backend<State> {
                 "entrant1.2.region": String(prs[1]?.region || ""),
                 "entrant1.2.winner":
                   qs.winnerIdx === 0 ? IMAGES.winner : IMAGES.default,
+
+                "entrant1.3.name": qs.left?.player3?.name || "TBD",
+                "entrant1.3.sponsor": qs.left?.player3?.sponsor || "",
+                "entrant1.3.sponsorPath": qs.left?.player3?.sponsor
+                  ? IMAGES.sponsor
+                  : IMAGES.blank,
+                "entrant1.3.country": getCountryFlag(qs.left?.player3?.country),
+                "entrant1.3.face": getLegendHead(qs.left?.player3?.legend),
+                "entrant1.3.legend": getLegendFull(qs.left?.player3?.legend),
+                ...getLegendOffset(qs.left?.player3?.legend, "entrant1.3"),
+                "entrant1.3.pr": String(prs[4]?.pr || "-"),
+                "entrant1.3.region": String(prs[4]?.region || ""),
+                "entrant1.3.winner":
+                  qs.winnerIdx === 0 ? IMAGES.winner : IMAGES.default,
                 "entrant2.name": entrantName(qs.right) || "TBD",
                 "entrant2.score": qs.rightScore || 0,
                 "entrant2.1.name": qs.right?.player1?.name || "TBD",
@@ -514,6 +532,22 @@ export class QueueBackend extends Backend<State> {
                 "entrant2.2.pr": String(prs[3]?.pr || "-"),
                 "entrant2.2.region": String(prs[3]?.region || ""),
                 "entrant2.2.winner":
+                  qs.winnerIdx === 1 ? IMAGES.winner : IMAGES.default,
+
+                "entrant2.3.name": qs.right?.player3?.name || "TBD",
+                "entrant2.3.sponsor": qs.right?.player3?.sponsor || "",
+                "entrant2.3.sponsorPath": qs.right?.player3?.sponsor
+                  ? IMAGES.sponsor
+                  : IMAGES.blank,
+                "entrant2.3.country": getCountryFlag(
+                  qs.right?.player3?.country
+                ),
+                "entrant2.3.face": getLegendHead(qs.right?.player3?.legend),
+                "entrant2.3.legend": getLegendFull(qs.right?.player3?.legend),
+                ...getLegendOffset(qs.right?.player3?.legend, "entrant2.3"),
+                "entrant2.3.pr": String(prs[5]?.pr || "-"),
+                "entrant2.3.region": String(prs[5]?.region || ""),
+                "entrant2.3.winner":
                   qs.winnerIdx === 1 ? IMAGES.winner : IMAGES.default,
               };
             })

--- a/packages/core/src/client/pages/cards/lower-thirds.tsx
+++ b/packages/core/src/client/pages/cards/lower-thirds.tsx
@@ -200,15 +200,14 @@ export const LowerThirds = forwardRef<HTMLDivElement, CardProps>(
           isDoubles || isTrios ? winningPlayer.player2?.name : null,
           isTrios ? winningPlayer.player3?.name : null,
         ].filter((n) => n);
-        const winningPlayerName =
-          winningNames.length > 1
-            ? `${winningNames.slice(0, -1).join(", ")} AND ${
-                winningNames[winningNames.length - 1]
-              }`
-            : winningNames[0];
-        const gameMode = isTrios ? "TRIOS" : isDoubles ? "DOUBLES" : "SINGLES";
+        const winningPlayerName = isTrios
+          ? winningNames.join(", ")
+          : winningNames.join(" AND ");
+        const gameMode = isTrios ? "" : isDoubles ? "DOUBLES" : "SINGLES";
         const champText = isDoubles || isTrios ? "CHAMPIONS" : "CHAMPION";
-        const eventString = `${tourneyName} ${gameMode} ${champText}`;
+        const eventString = [tourneyName, gameMode, champText]
+          .filter(Boolean)
+          .join(" ");
         states.champion[0][1]({
           ...states.champion[0][1],
           title: eventString,

--- a/packages/core/src/client/pages/cards/lower-thirds.tsx
+++ b/packages/core/src/client/pages/cards/lower-thirds.tsx
@@ -194,11 +194,20 @@ export const LowerThirds = forwardRef<HTMLDivElement, CardProps>(
         const isLeftWinner = (leftPlayer.score ?? 0) > (rightPlayer.score ?? 0);
         const winningPlayer = isLeftWinner ? leftPlayer : rightPlayer;
         const isDoubles = !!winningPlayer.player2?.name;
-        let winningPlayerName = winningPlayer.player1?.name ?? "-";
-        if (isDoubles)
-          winningPlayerName += ` AND ${winningPlayer.player2?.name}`;
-        const gameMode = isDoubles ? "DOUBLES" : "SINGLES";
-        const champText = isDoubles ? "CHAMPIONS" : "CHAMPION";
+        const isTrios = !!winningPlayer.player3?.name;
+        const winningNames = [
+          winningPlayer.player1?.name ?? "-",
+          isDoubles || isTrios ? winningPlayer.player2?.name : null,
+          isTrios ? winningPlayer.player3?.name : null,
+        ].filter((n) => n);
+        const winningPlayerName =
+          winningNames.length > 1
+            ? `${winningNames.slice(0, -1).join(", ")} AND ${
+                winningNames[winningNames.length - 1]
+              }`
+            : winningNames[0];
+        const gameMode = isTrios ? "TRIOS" : isDoubles ? "DOUBLES" : "SINGLES";
+        const champText = isDoubles || isTrios ? "CHAMPIONS" : "CHAMPION";
         const eventString = `${tourneyName} ${gameMode} ${champText}`;
         states.champion[0][1]({
           ...states.champion[0][1],

--- a/packages/core/src/client/support/hooks.ts
+++ b/packages/core/src/client/support/hooks.ts
@@ -140,4 +140,6 @@ export function useUpdate(effect: () => void, dependencies: any[] = []) {
 }
 
 export const entrantName = (e: Entrant) =>
-  [e?.player1?.name, e?.player2?.name].filter((a) => a).join("/");
+  [e?.player1?.name, e?.player2?.name, e?.player3?.name]
+    .filter((a) => a)
+    .join("/");

--- a/packages/core/src/client/ui/components/entrants/index.tsx
+++ b/packages/core/src/client/ui/components/entrants/index.tsx
@@ -48,7 +48,9 @@ export function useEntrantOptions(entrants: Entrant[], prefetch = true) {
     Promise.all(
       candidates.map((e) => {
         const name = e.player1?.name
-          ? [e.player1.name, e.player2?.name].filter((a) => a).join(" / ")
+          ? [e.player1.name, e.player2?.name, e.player3?.name]
+              .filter((a) => a)
+              .join(" / ")
           : "Loading...";
         entrantOptions.push({ name, value: String(e.id) });
         loading.current.add(String(e.id));
@@ -235,6 +237,7 @@ export function EntrantColumn({
   name,
   entrant,
   isTwos,
+  isThrees,
   entrantOptions,
   modifyEntrants,
   withScore,
@@ -248,6 +251,7 @@ export function EntrantColumn({
   name: string;
   entrant: Entrant;
   isTwos?: boolean;
+  isThrees?: boolean;
   extras?: (e: Entrant, sE: SetEntrant) => React.ReactNode;
   after?: (e: Entrant, sE: SetEntrant) => React.ReactNode;
 
@@ -279,6 +283,7 @@ export function EntrantColumn({
                 isLive: !isLive,
                 player1: {},
                 player2: {},
+                player3: {},
               });
             }}
           >
@@ -324,6 +329,7 @@ export function EntrantColumn({
               isLive: true,
               player1: {},
               player2: {},
+              player3: {},
             });
           }}
         />
@@ -357,12 +363,12 @@ export function EntrantColumn({
       )}
       <PlayerFields
         disabled={disabled}
-        playerNumber={isTwos && 1}
+        playerNumber={(isTwos || isThrees) && 1}
         player={entrant.player1}
         setPlayer={(p) => setEntrant({ ...entrant, player1: p })}
         fields={playerFields}
       />
-      {isTwos && (
+      {(isTwos || isThrees) && (
         <>
           <hr />
           <PlayerFields
@@ -370,6 +376,18 @@ export function EntrantColumn({
             playerNumber={2}
             player={entrant.player2}
             setPlayer={(p) => setEntrant({ ...entrant, player2: p })}
+            fields={playerFields}
+          />
+        </>
+      )}
+      {isThrees && (
+        <>
+          <hr />
+          <PlayerFields
+            disabled={disabled}
+            playerNumber={3}
+            player={entrant.player3}
+            setPlayer={(p) => setEntrant({ ...entrant, player3: p })}
             fields={playerFields}
           />
         </>
@@ -418,6 +436,7 @@ export function EntrantColumns({
   setRightScore?: (s: number) => void;
 }) {
   const isTwos = entrantSize === 2;
+  const isThrees = entrantSize === 3;
   const swapSides = () => (setLeft(right), setRight(left));
   const { entrantOptions, getEntrantOptions } = useEntrantOptions(
     [left, right],
@@ -431,6 +450,7 @@ export function EntrantColumns({
     afterPlayer,
     getEntrantOptions,
     isTwos,
+    isThrees,
     entrantOptions,
     modifyEntrants,
     withScore,
@@ -481,7 +501,9 @@ export function EntrantPredictions({
   setThird: SetEntrant;
   modifyEntrants?: boolean;
 }) {
-  const isTwos = useSggTournament().entrantSize === 2;
+  const sggEntrantSize = useSggTournament().entrantSize;
+  const isTwos = sggEntrantSize === 2;
+  const isThrees = sggEntrantSize === 3;
   const { entrantOptions, getEntrantOptions } = useEntrantOptions([
     first,
     second,
@@ -493,12 +515,14 @@ export function EntrantPredictions({
     | "entrantOptions"
     | "getEntrantOptions"
     | "isTwos"
+    | "isThrees"
     | "modifyEntrants"
     | "playerFields"
   > = {
     entrantOptions,
     getEntrantOptions,
     isTwos,
+    isThrees,
     modifyEntrants,
     playerFields: ["sponsor", "name", "legend", "country"],
   };

--- a/packages/core/src/services/player.ts
+++ b/packages/core/src/services/player.ts
@@ -18,10 +18,7 @@ import {
   TTournamentBackend,
 } from "@bmg-esports/gjallarhorn-tokens";
 import { TournamentBackend } from "../backends/pages/tournament";
-import {
-  GQLTournamentLineup,
-  GQLUserProfile,
-} from "../@types/challengermode";
+import { GQLTournamentLineup, GQLUserProfile } from "../@types/challengermode";
 
 @injectable()
 export class PlayerService {
@@ -73,9 +70,13 @@ export class PlayerService {
 
     e.player1 = users[0];
     e.player2 = {};
+    e.player3 = {};
 
-    if (users.length === 2) {
+    if (users.length >= 2) {
       e.player2 = users[1];
+    }
+    if (users.length >= 3) {
+      e.player3 = users[2];
     }
 
     return e;
@@ -199,13 +200,12 @@ export class PlayerService {
 
   async getPR(playerId: number) {
     if (!playerId) return null;
+    const gameMode = this.t.state.isChallengerMode
+      ? this.t.state.cmTournament.entrantSize
+      : this.t.state.sggTournament.entrantSize;
+    if (gameMode === 3) return null;
     try {
-      return await this.db.getPlayerPR(
-        playerId,
-        this.t.state.isChallengerMode
-          ? this.t.state.cmTournament.entrantSize
-          : this.t.state.sggTournament.entrantSize
-      );
+      return await this.db.getPlayerPR(playerId, gameMode);
     } catch (e) {
       if (e instanceof BackendError) {
         this.errors.report(e.nonFatal());
@@ -222,6 +222,7 @@ export class PlayerService {
       const gameMode = this.t.state.isChallengerMode
         ? this.t.state.cmTournament.entrantSize
         : this.t.state.sggTournament.entrantSize;
+      if (gameMode === 3) return null;
       const events = await this.db.getPlayerEvents(playerId, gameMode);
       const allMatches = events.map(async (event) =>
         this.db.getPlayerEventMatches(playerId, event.tournament.id)
@@ -247,6 +248,7 @@ export class PlayerService {
     const gameMode = this.t.state.isChallengerMode
       ? this.t.state.cmTournament.entrantSize
       : this.t.state.sggTournament.entrantSize;
+    if (gameMode === 3) return [0, 0];
     const entrant1PlayerIds = [left?.player1?.id],
       entrant2PlayerIds = [right?.player1?.id];
     if (gameMode === 2) {


### PR DESCRIPTION
Extends the existing 1v1 / 2v2 codepaths to support 3v3 lineups for Challenger Mode tournaments. Style and layout match the existing 2v2 conventions. This was mainly made to support brawlball but should support other 3v3 formats.

### Data + parsing
- `Entrant` gains `player3?: Player`.
- `PlayerService.parseLineup` fills `player3` from the 3rd CM lineup member.
- Stat lookups (`getPR`, `getPlayerWinrate`, `getMatchup`) early-return null / `[0, 0]` when `gameMode === 3` — gated off until DB has trios data.

### Backends
- `QueueBackend.entrantName` joins all three names; `push()` writes `entrant{1,2}.3.*` JSON keys and PR lookups for both player3 ids.
- `GameBackend.emptyEntrant()` includes `player3`; `pushGame()` emits both `player3`s in `game.json` and `live/game.json`.
- `PlayersBackend` default state, listener resets, and `pushPlayers()` include `player3`.

### UI
- `EntrantColumn` / `EntrantColumns` add an `isThrees` flag alongside `isTwos` and render a 3rd `<PlayerFields>` block with the same separator pattern when `entrantSize === 3`. All entrant-reset paths include `player3: {}`.
- Lower-thirds `autoFillChampion` emits `"<TOURNEY> CHAMPIONS"` (Unlike `"<TOURNEY> DOUBLES CHAMPIONS"`) and joins names as `"A, B, C"` for trios.
- `entrantName` helper (client) includes `player3`.

### Known Limitations
- **start.gg side not implemented**
- **`PlayerService.getMatchup` always returns `[0, 0]` for 3v3.** No matchup history exists in the DB for `gameMode = 3`, so the lifetime-score field on the Players card will always be `0` for trios.
- **`PlayerService.getPlayerWinrate` always returns `null` for 3v3.** Same reason. The Players card will show `"-"`.
- **`PlayerService.getPR` always returns `null` for 3v3.** PR / earnings / top8 / top32 / medals all show `"-"` or `0` for trios entrants.