### PR TITLE
Set up a docker workflow

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,30 @@
+name: Publish Docker Image
+
+on:
+  push:
+    branches: ["main", "challengerModeUpdate"]
+
+jobs:
+  publish:
+    name: Publish Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        env:
+          DOCKER_TAG: ${{ github.ref_name == 'main' && 'latest' || github.ref_name }}
+        with:
+          push: true
+          tags: shmeee/gjallarhorn:${{ env.DOCKER_TAG }}
+          file: ./docker/Dockerfile

--- a/README.md
+++ b/README.md
@@ -6,16 +6,13 @@ Gjallarhorn is a tool for Brawlhalla community tournament producers to generate 
 
 You will need a start.gg API key to use Gjallarhorn. If you don't have one already, get one at https://developer.start.gg/docs/authentication.
 
-To start Gjallarhorn, run the following commands in the project:
+To start Gjallarhorn, you can install [Docker Desktop](https://www.docker.com/products/docker-desktop/).
+
+Once this has installed open Powershell and run:
 
 ```sh
-npm install
-npm run build
-node . -s [your-startgg-key-here]
+docker run -it --rm -e GJALLARHORN_STARTGG=[your-startgg-key-here] -p 3000:3000 shmeee/gjallarhorn:latest
 ```
-
-> [!NOTE]
-> You only need to run `npm install` and `npm run build` the first time you try to run Gjallarhorn.
 
 Then, launch the dashboard at http://localhost:3000.
 
@@ -122,6 +119,14 @@ You can create presets for each section. You can also delete the most recently c
 </details>
 
 ## Development Overview
+
+To run Gjallarhorn locally, use the following:
+
+```sh
+npm install
+npm run build
+node . -s [your-startgg-key-here]
+```
 
 Gjallarhorn consists of a React front end and a NodeJS backend. The NodeJS
 backends act as data stores for the data input into the cards. Backend updates

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,11 @@
 # Use the official Node.js 16 image as the base image
-FROM node:16-slim
+FROM node:24-slim
 
 # Set the working directory
 WORKDIR /app
 
 # Copy package.jsons (including nested) and package-lock.json
-COPY package.json package-lock.json .
+COPY package.json package-lock.json ./
 COPY packages packages
 RUN find packages \! -name "package.json" -mindepth 2 -maxdepth 2 -print | xargs rm -rf
 


### PR DESCRIPTION
allows the docker image to be built and shared automatically for startgg and challengermode

adds description to readme for this

makes a couple improvements to the dockerfile, updates node

to set up in your repo you will need to do the following:

- create an account on docker hub if you've not one already
- in account settings, go to personal access tokens and make one with read, write, delete
- add them as github secrets to your repo as
  - DOCKER_USERNAME (your docker username)
  - DOCKER_PASSWORD (PAT generated)

see https://github.com/shme-e/gjallarhorn/actions/runs/25606234933 for an example run

hopefully this makes gjallarhorn a little easier to set up, cloning the repo is no longer a requirement

note I haven't been able to actually try this with startgg, I've only been using challengermode. testing appreciated!